### PR TITLE
Speed up Insert

### DIFF
--- a/radix.go
+++ b/radix.go
@@ -40,8 +40,14 @@ func (n *node) isLeaf() bool {
 }
 
 func (n *node) addEdge(e edge) {
-	n.edges = append(n.edges, e)
-	n.edges.Sort()
+	num := len(n.edges)
+	idx := sort.Search(num, func(i int) bool {
+		return n.edges[i].label >= e.label
+	})
+
+	n.edges = append(n.edges, edge{})
+	copy(n.edges[idx+1:], n.edges[idx:])
+	n.edges[idx] = e
 }
 
 func (n *node) updateEdge(label byte, node *node) {

--- a/radix_test.go
+++ b/radix_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"testing"
 )
 
@@ -356,4 +357,18 @@ func generateUUID() string {
 		buf[6:8],
 		buf[8:10],
 		buf[10:16])
+}
+
+func BenchmarkInsert(b *testing.B) {
+	r := New()
+	for i := 0; i < 10000; i++ {
+		r.Insert(fmt.Sprintf("init%d", i), true)
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_, updated := r.Insert(strconv.Itoa(n), true)
+		if updated {
+			b.Fatal("bad")
+		}
+	}
 }


### PR DESCRIPTION
Rewrite `addEdge` to use binary search to insert the element in the already sorted slice.

Benchmark for `Insert`:

```
name       old time/op    new time/op    delta
Insert-16     624ns ± 4%     523ns ± 3%  -16.29%  (p=0.029 n=4+4)

name       old alloc/op   new alloc/op   delta
Insert-16      169B ± 0%      137B ± 0%  -18.93%  (p=0.029 n=4+4)

name       old allocs/op  new allocs/op  delta
Insert-16      4.00 ± 0%      3.00 ± 0%  -25.00%  (p=0.029 n=4+4)
```

Closes #15